### PR TITLE
Remove Default Directory for Select Dialogs

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -13,7 +13,7 @@ srm = None
 #
 def select_ves():
     global ves
-    inputf = filedialog.askopenfilename(initialdir="/", title="Select .VES file", filetypes=((".VES File", "*.ves"), ("All files", "*.*")))
+    inputf = filedialog.askopenfilename(title="Select .VES file", filetypes=((".VES File", "*.ves"), ("All files", "*.*")))
     base = os.path.basename(inputf)
     if os.path.splitext(base)[1].lower() == '.ves':
         ves = inputf
@@ -22,7 +22,7 @@ def select_ves():
 
 def select_srm():
     global srm
-    inputf = filedialog.askopenfilename(initialdir="/", title="Select .SRM file", filetypes=((".SRM File", "*.srm"), ("All files", "*.*")))
+    inputf = filedialog.askopenfilename(title="Select .SRM file", filetypes=((".SRM File", "*.srm"), ("All files", "*.*")))
     base = os.path.basename(inputf)
     if os.path.splitext(base)[1].lower() == '.srm':
         srm = inputf

--- a/gui.py
+++ b/gui.py
@@ -13,7 +13,7 @@ srm = None
 #
 def select_ves():
     global ves
-    inputf = filedialog.askopenfilename(title="Select .VES file", filetypes=((".VES File", "*.ves"), ("All files", "*.*")))
+    inputf = filedialog.askopenfilename(title="Select .VES file", initialdir=os.getcwd(), filetypes=((".VES File", "*.ves"), ("All files", "*.*")))
     base = os.path.basename(inputf)
     if os.path.splitext(base)[1].lower() == '.ves':
         ves = inputf
@@ -22,7 +22,7 @@ def select_ves():
 
 def select_srm():
     global srm
-    inputf = filedialog.askopenfilename(title="Select .SRM file", filetypes=((".SRM File", "*.srm"), ("All files", "*.*")))
+    inputf = filedialog.askopenfilename(title="Select .SRM file",  initialdir=os.getcwd(), filetypes=((".SRM File", "*.srm"), ("All files", "*.*")))
     base = os.path.basename(inputf)
     if os.path.splitext(base)[1].lower() == '.srm':
         srm = inputf


### PR DESCRIPTION
It is a bit confusing to run the program in a directory for it to then open the root of the computer as the location to start searching for rom saves. It would make more sense to have it use the location of the script since that is also where the functions save output to.